### PR TITLE
Randomize restart order

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Unreleased
+
+* Randomize order of service restarts.
+
 # 1.0.3
 
 * Write failures and timeouts to STDERR.

--- a/main.go
+++ b/main.go
@@ -8,10 +8,12 @@ import (
 	"flag"
 	"fmt"
 	"log"
+	"math/rand"
 	"os"
 	"os/exec"
 	"path"
 	"path/filepath"
+	"time"
 )
 
 const (
@@ -51,6 +53,8 @@ func (c config) AssertValid(pattern string) {
 }
 
 func init() {
+	rand.Seed(time.Now().UnixNano()) // init(), not main(), so that tests get it too.
+
 	oldUsage := flag.Usage
 	flag.Usage = func() {
 		oldUsage()
@@ -118,7 +122,16 @@ func getServices(pattern string) (services []string, err error) {
 	for _, p := range fullpaths {
 		services = append(services, path.Base(p))
 	}
+	shuffle(services)
 	return
+}
+
+// Fisher-Yates, Sattolo's algorithm
+func shuffle(a []string) {
+	for i := range a {
+		j := rand.Intn(i + 1)
+		a[i], a[j] = a[j], a[i]
+	}
 }
 
 func runCompletionHandler(command string) {

--- a/main.go
+++ b/main.go
@@ -62,18 +62,18 @@ func init() {
 	}
 }
 
-var (
-	canaryRatio            = flag.Float64("canary-ratio", 0.001, "canary nodes are restarted first. If they fail, the deploy is failed. Rounded up to the nearest node, unless set to zero")
-	canaryTimeoutTolerance = flag.Float64("canary-timeout-tolerance", 0, "ratio of canary nodes that are permitted to time out without causing the deploy to fail")
-	chunkRatio             = flag.Float64("chunk-ratio", 0.2, "after canary nodes, ratio of remaining nodes permitted to restart concurrently")
-	timeoutTolerance       = flag.Float64("timeout-tolerance", 0, "ratio of total nodes whose restarts may time out and still consider the deploy a success")
-	timeout                = flag.Int("timeout", 90, "number of seconds to wait for a service to restart before considering it timed out and moving on")
-	pattern                = flag.String("pattern", "", "(required) glob pattern to match /etc/service entries (e.g. \"borg-shopify-*\")")
-	onComplete             = flag.String("oncomplete", "", "command to execute when the deploy finishes (regardless of success)")
-	verbose                = flag.Bool("verbose", false, "print more information about what's going on")
-)
-
 func main() {
+	var (
+		canaryRatio            = flag.Float64("canary-ratio", 0.001, "canary nodes are restarted first. If they fail, the deploy is failed. Rounded up to the nearest node, unless set to zero")
+		canaryTimeoutTolerance = flag.Float64("canary-timeout-tolerance", 0, "ratio of canary nodes that are permitted to time out without causing the deploy to fail")
+		chunkRatio             = flag.Float64("chunk-ratio", 0.2, "after canary nodes, ratio of remaining nodes permitted to restart concurrently")
+		timeoutTolerance       = flag.Float64("timeout-tolerance", 0, "ratio of total nodes whose restarts may time out and still consider the deploy a success")
+		timeout                = flag.Int("timeout", 90, "number of seconds to wait for a service to restart before considering it timed out and moving on")
+		pattern                = flag.String("pattern", "", "(required) glob pattern to match /etc/service entries (e.g. \"borg-shopify-*\")")
+		onComplete             = flag.String("oncomplete", "", "command to execute when the deploy finishes (regardless of success)")
+		verbose                = flag.Bool("verbose", false, "print more information about what's going on")
+	)
+
 	flag.Parse()
 	config := config{
 		CanaryRatio:            *canaryRatio,

--- a/sv-rollout_test.go
+++ b/sv-rollout_test.go
@@ -9,6 +9,31 @@ import (
 
 func TestSvRollout(t *testing.T) {
 
+	Convey("Shuffling services", t, func() {
+		defer func() {
+			globServices = filepath.Glob
+		}()
+		unexpected := []string{"a", "b", "c", "d", "e", "f", "g", "h"}
+		globServices = func(a string) ([]string, error) {
+			var rets []string
+			for _, str := range unexpected {
+				rets = append(rets, "/etc/service/"+(str))
+			}
+			return rets, nil
+		}
+		svcs, err := getServices("borg-shopify-*")
+
+		Convey("Services should be shuffled", func() {
+			So(err, ShouldBeNil)
+			So(len(svcs), ShouldEqual, len(unexpected))
+			for _, str := range unexpected {
+				So(svcs, ShouldContain, str)
+			}
+			// Tiny possibility of random failure.
+			So(svcs, ShouldNotResemble, unexpected)
+		})
+	})
+
 	Convey("Enumerating services", t, func() {
 		defer func() {
 			globServices = filepath.Glob
@@ -20,7 +45,9 @@ func TestSvRollout(t *testing.T) {
 
 		Convey("Should generate corrcect service names", func() {
 			So(err, ShouldBeNil)
-			So(svcs, ShouldResemble, []string{"borg-shopify-test-1", "borg-shopify-test-2"})
+			So(len(svcs), ShouldEqual, 2)
+			So(svcs, ShouldContain, "borg-shopify-test-1")
+			So(svcs, ShouldContain, "borg-shopify-test-2")
 		})
 	})
 


### PR DESCRIPTION
@graemej @Sirupsen 

Right now it restarts them all in lexicographical order, which is fine, but I think the randomness will serve us better.

This is especially true as I'm about to change it to return early if the timeout acceptance threshold has been reached while there are still a final batch of processes restarting.