### PR TITLE
Switch destination repository from Shopify/stable to Shopify/public.

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -14,5 +14,5 @@ deployment:
     commands:
       - gem install package_cloud
       - script/build
-      - PACKAGE=$(ls pkg|grep deb) && PACKAGECLOUD_TOKEN=$PACKAGECLOUD_TOKEN package_cloud push --url https://packages.shopify.io shopify/stable/ubuntu/trusty pkg/$PACKAGE
-      - PACKAGE=$(ls pkg|grep deb) && PACKAGECLOUD_TOKEN=$PACKAGECLOUD_TOKEN package_cloud push --url https://packages.shopify.io shopify/stable/ubuntu/precise pkg/$PACKAGE
+      - PACKAGE=$(ls pkg|grep deb) && PACKAGECLOUD_TOKEN=$PACKAGECLOUD_TOKEN package_cloud push --url https://packages.shopify.io shopify/public/ubuntu/trusty pkg/$PACKAGE
+      - PACKAGE=$(ls pkg|grep deb) && PACKAGECLOUD_TOKEN=$PACKAGECLOUD_TOKEN package_cloud push --url https://packages.shopify.io shopify/public/ubuntu/precise pkg/$PACKAGE


### PR DESCRIPTION
Part of the clean-up effort for https://github.com/Shopify/secops/issues/73.  Will be cleaned up once we are able to make `Shopify/stable` a private repository.

@burke @mutemule @JonPulsifer 
